### PR TITLE
Add link that points to the full ayab-manual to prevent that users overlook it:

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -4,7 +4,7 @@ title: Quick Start
 permalink: /quick-start/
 ---
 
-or you have a look at this [nice tutorial by Claire Williams](http://xxxclairewilliamsxxx.wordpress.com/hack-ta-machine-a-tricoter/hack-your-knitting-machine-tutorial/)
+or you have a look at this [nice tutorial by Claire Williams](http://xxxclairewilliamsxxx.wordpress.com/hack-ta-machine-a-tricoter/hack-your-knitting-machine-tutorial/). See the [full-length AYAB manual](https://manual.ayab-knitting.com/) for details.
 
 ### 1. Install the Hardware into your Machine
 


### PR DESCRIPTION
The added link in quick-start.md prevents that users who click on ayab-knitting.com -> documentation and immediately start reading the quick start guide overlook the documentation-dropdown menu with the full manual .  